### PR TITLE
CPU Input Boost/MSM Limiter: use correct ApplyOnBoot id

### DIFF
--- a/app/src/main/java/com/smartpack/kernelmanager/utils/CPUInputBoost.java
+++ b/app/src/main/java/com/smartpack/kernelmanager/utils/CPUInputBoost.java
@@ -157,7 +157,7 @@ public class CPUInputBoost {
     }
 
     private static void run(String command, String id, Context context) {
-        Control.runSetting(command, ApplyOnBootFragment.CPU_HOTPLUG, id, context);
+        Control.runSetting(command, ApplyOnBootFragment.CPU, id, context);
     }
 
 }

--- a/app/src/main/java/com/smartpack/kernelmanager/utils/MSMLimiter.java
+++ b/app/src/main/java/com/smartpack/kernelmanager/utils/MSMLimiter.java
@@ -82,7 +82,7 @@ public class MSMLimiter {
     }
 
     private static void run(String command, String id, Context context) {
-        Control.runSetting(command, ApplyOnBootFragment.CPU_HOTPLUG, id, context);
+        Control.runSetting(command, ApplyOnBootFragment.CPU, id, context);
     }
 
 }


### PR DESCRIPTION
Signed-off-by: sunilpaulmathew <sunil.kde@gmail.com>